### PR TITLE
#5 fix + delayed fade to black JS prevents flickering during page load & Twenty/Slick setup.

### DIFF
--- a/_includes/debug-pages.html
+++ b/_includes/debug-pages.html
@@ -10,7 +10,11 @@
     <tt>site.url : {{ site.url }}</tt> &mdash;
     <a href="http://matthieucadet.info">go to <b>matthieucadet.info</b></a>
   </div>
-  {% assign pages_list = site.pages | sort:"date" | reverse %}
+  {% assign pages_list = site.pages %}
+  {% assign posts_list = site.posts | sort:"date" | reverse %}
+  {% for item in posts_list %}
+    {% assign pages_list = pages_list | push: item %}
+  {% endfor %}
     <table class="pages-list">
       <thead>
         <tr>
@@ -22,7 +26,7 @@
       </thead>
       <tbody>
       {% for node in pages_list %}
-        {% unless node.layout == 'default' or node.layout == null %}
+        {% if node.layout != null %}
           <tr>
             <th>
               {{ forloop.index }}
@@ -61,7 +65,7 @@
               {% endif %}
             </td>
           </tr>
-        {% endunless %}
+        {% endif %}
       {% endfor %}
       </tbody>
     </table>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,6 +32,7 @@
     <link rel="stylesheet" href="{{ "/css/slick_custom.css" | relative_url }}">
   {% endif %}
 
+  {% comment %} TODO: See /index-fp.html & _layouts/default-fp.html {% endcomment %}
   {% if true %}
     <link rel="stylesheet" type="text/css" href="/css/jquery.fullpage.css" />
   {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-us">
   {% include head.html %}
-  <body{% if page.fade_to_black %} class="fade-to-black"{% endif %}>
+  <!-- body{% if page.fade_to_black %} class="fade-to-black"{% endif %}
+       ^ Replaced by JS func. FadePageToBlack() which adds the `fade-to-black`
+         class after a timeout has elapsed so as to prevent rendering flicker. -->
+  <body>
     {% include sidebar.html %}
 
     <!-- Wrap is the content to shift when toggling the sidebar. We wrap the
@@ -50,7 +53,7 @@
       <script src="{{ "/assets/jquery.twentytwenty.js" | relative_url }}"></script>
       <script src="{{ "/assets/jquery.event.move.js" | relative_url }}"></script>
 
-      <script type="text/javascript">
+      <script type="text/javascript"> <!-- Function decls -->
         /**
          * Setup func. that does 2 things: setup TwentyTwenty on stuff that have
          * have class 'twentytwenty-container', then initialize Slick which will
@@ -95,6 +98,44 @@
           console.info(">> PleaseSetupGalleryCompare(): done! <<");
         }
 
+        /** Fade page to black by adding CSS class 'fade-to-black'
+         * to `element` (default: body).  Argument `wantPageFadeToBlack` may be
+         * a number, in which case it is the number of milliseconds we should
+         * wait before acting.
+         *
+         * Usage:
+         *   - `FadePageToBlack(true); // add CSS class immediately.`
+         *   - `FadePageToBlack(800);  // delay by 800 msecs. `
+         *
+         * Written for /compositing_work.html page which is CPU-heavy
+         * and causes rendering flicker on F's old computer -_-
+         *
+         * @param {bool|number} wantPageFadeToBlack  true/false/number.
+         * @param {string}      element              Default: "body".
+         */
+        function FadePageToBlack(wantPageFadeToBlack, element) {
+          element = element || "body";
+          if (wantPageFadeToBlack == false)
+            return;
+          // Prevent duplicate invocations.
+          else if (jQuery(element).hasClass("fade-to-black")) {
+            console.warn("FadePageToBlack(): element already has the 'fade-to-black' class");
+            return;
+          }
+          else {
+            console.info("Adding .fade-to-black to element: " + element
+                         + " (delayed by " + delay_millisecs + " milliseconds).");
+            var delay_millisecs = +wantPageFadeToBlack ;
+            jQuery().ready(function(event) {
+              window.setTimeout(function(elt) {
+                jQuery( elt ).addClass("fade-to-black");
+              }, delay_millisecs, element);
+            });
+          }
+        }
+      </script> <!--/ ^ functions -->
+
+    <script> <!-- Twenty/Slick gallery setup code -->
         // Wait for document ready (previous impl.):
         if( false ) {
           $(document).ready(function() {
@@ -126,7 +167,7 @@
               console.info("imageLoaded 'always' handler: "
                            + "invoking `PleaseSetupGalleryCompare()` now (!!).");
               PleaseSetupGalleryCompare();
-              //console.log(instance);
+              FadePageToBlack({{ page.fade_to_black | to_integer }});
               console.info("imageLoaded processed "
                 + instance.progressedCount
                 + " images (or sthg like that).");
@@ -169,7 +210,7 @@
               //
             });
         }
-    </script>
+    </script> <!-- Twenty/Slick gallery setup code -->
     {% endif %}
 
     {% include disqus.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-us">
   {% include head.html %}
-  <body>
+  <body{% if page.fade_to_black %} class="fade-to-black"{% endif %}>
     {% include sidebar.html %}
 
     <!-- Wrap is the content to shift when toggling the sidebar. We wrap the

--- a/compositing_work.html
+++ b/compositing_work.html
@@ -3,6 +3,7 @@ layout: page
 published: true
 title: Compositing Work
 gallery_compare: true
+fade_to_black: true
 permalink: /work/compositing/
 ---
 

--- a/compositing_work.html
+++ b/compositing_work.html
@@ -3,7 +3,8 @@ layout: page
 published: true
 title: Compositing Work
 gallery_compare: true
-fade_to_black: true
+#fade_to_black: true
+fade_to_black: 1000  # delay fade by X msecs (avoids "flickering").
 permalink: /work/compositing/
 ---
 

--- a/css/maty.css
+++ b/css/maty.css
@@ -5,6 +5,28 @@
    Maty/974 CSS
  */
 
+@-webkit-keyframes target-fade {
+  0% { background-color: white; }
+  100% { background-color: #252726; }
+}
+
+@-moz-keyframes target-fade {
+  0% { background-color: white; }
+  100% { background-color: #252726; }
+}
+
+.fade-to-black {
+    background: #252726;
+    -webkit-animation: target-fade 3s 1;
+    -moz-animation: target-fade 3s 1;
+}
+
+/* See _layouts/default.html and Liquid var. `fade_to_black: true` */
+.page-title { color: #303030; }
+.fade-to-black .page-title { color: #cccaca; }
+
+/* .body-white { background: white; } */
+
 .run-974 {
   color: inherit;
   font-size: small;

--- a/css/slick_custom.css
+++ b/css/slick_custom.css
@@ -20,6 +20,13 @@
   font-size: 40px;
 }
 
+.fade-to-black .slick-prev:before,
+.fade-to-black .slick-next:before
+{
+  color: #fbfafa;
+  font-size: 40px;
+}
+
 .slick-prev
 {
     left: -45px;

--- a/debug-page.html
+++ b/debug-page.html
@@ -1,8 +1,0 @@
----
-layout: page
-published: false
-title: Debug page
-permalink: /debug+me/
----
-
-{% include debug-pages.html %}

--- a/debug-page.md
+++ b/debug-page.md
@@ -1,0 +1,12 @@
+---
+layout: page
+published: false
+title: Debug page
+permalink: /debug+me/
+---
+
+{% include debug-pages.html %}
+
+* [__Jekyll cheatsheet @ devhints.io__](https://devhints.io/jekyll)
+* [Jekyll Cheat Sheet @ CloudCannon](https://learn.cloudcannon.com/jekyll-cheat-sheet/)
+* [Jekyllrb : variables](https://jekyllrb.com/docs/variables/)


### PR DESCRIPTION
Revert & tentative fix #5 + new FadePageToBlack() which does `<body class="fade-to-black">` after a delay  --> because my Linux box is so slow that the page flickers, like, really really bad when Chrome tries to fade-to-black _while_ loading the image _then_ setup Twenty + Slick.